### PR TITLE
61 reduce w weight

### DIFF
--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -291,6 +291,7 @@ def reduce_one_variable(obs, variable, weights, reduce_amount):
     :param obs: [pandas df] the observation data
     :param variable: [str] the variable to reduce (i.e., 'seg_tave_water' or
     'seg_outflow')
+    oparam weights:[xr dataset] weights that will be changed
     :param reduce_amount: [float] fraction to reduce the training data by.
     For example, if 0.9, a random 90% of the weights in the training data for
     the variable will be set to zero
@@ -301,7 +302,7 @@ def reduce_one_variable(obs, variable, weights, reduce_amount):
     non_null = variable_series[variable_series.notnull()]
     reduce_idx = non_null.sample(frac=reduce_amount).index
     weights.loc[reduce_idx, variable] = 0
-    return obs
+    return weights
 
 
 def reduce_training_data(y_obs, weights, reduce_temp_trn, reduce_flow_trn):
@@ -316,13 +317,13 @@ def reduce_training_data(y_obs, weights, reduce_temp_trn, reduce_flow_trn):
     :param reduce_flow_trn: [float] fraction to reduce the flow training data
     by. For example, if 0.9, a random 90% of the weights for the flow
     training data will be set to zero
-    :return: [xarray dataset] updated weights (zero's where reduced)
+    :return: [xarray dataset] updated weights (zeros where reduced)
     """
     weights = weights.to_dataframe()
     df = y_obs.to_dataframe()
     wgt_reduced = reduce_one_variable(df, 'seg_tave_water', weights,
                                       reduce_temp_trn)
-    wgt_reduced = reduce_one_variable(wgt_reduced, 'seg_outflow', wgt_reduced,
+    wgt_reduced = reduce_one_variable(df, 'seg_outflow', wgt_reduced,
                                       reduce_flow_trn)
     return wgt_reduced.to_xarray()
 

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -260,25 +260,31 @@ def change_weights_by_outcols(weights, out_cols):
     return weights
 
 
-def create_weight_vectors(y_data, out_cols, exclude_segs):
+def create_weight_vectors(y_data, reduce_temp_trn, reduce_flow_trn,
+                          exclude_segs):
     """
-    filter out either flow, temperature, or neither in the pre-training and
+    reduce either flow, temperature, or neither in the pre-training and
     finetune y data
-    :param y_data: [xr dataset]
-    :param out_cols: [str] which columns to have count in the loss function;
-    either 'temp', 'flow', or 'both'
+    :param y_data: [xr dataset] y_data
+    :param reduce_temp_trn: [float] fraction to reduce the temperature training
+    data by. For example, if 0.9, a random 90% of the weights for the
+    temperature training data will be set to zero
+    :param reduce_flow_trn: [float] fraction to reduce the flow training data
+    by. For example, if 0.9, a random 90% of the weights for the flow
+    training data will be set to zero
     :param exclude_segs: [list] list of segment ids to exclude from the loss
     function
     :return: [xr dataset] dataset of weights between one and zero
     """
     initial_weights = initialize_weights(y_data, 1)
-    weights = change_weights_by_outcols(initial_weights, out_cols)
+    weights = reduce_training_data(y_data, initial_weights, reduce_temp_trn,
+                                   reduce_flow_trn)
     if exclude_segs:
         weights = exclude_segments(weights, exclude_segs)
     return weights
 
 
-def reduce_one_variable(obs, variable, reduce_amount):
+def reduce_one_variable(obs, variable, weights, reduce_amount):
     """
     change a specified percentage of observation values to NaN for a given
     variable. The values that are changed are chosen randomly
@@ -286,34 +292,39 @@ def reduce_one_variable(obs, variable, reduce_amount):
     :param variable: [str] the variable to reduce (i.e., 'seg_tave_water' or
     'seg_outflow')
     :param reduce_amount: [float] fraction to reduce the training data by.
-    For example, if 0.9, 90% of the training data will be changed to NaN
-    :return: [pandas df] data with the percentage of training data changed to
-    Nan
+    For example, if 0.9, a random 90% of the weights in the training data for
+    the variable will be set to zero
+    :return: [pandas df] data with the percentage of training data weights
+    changed to zero
     """
     variable_series = obs[variable]
     non_null = variable_series[variable_series.notnull()]
     reduce_idx = non_null.sample(frac=reduce_amount).index
-    obs.loc[reduce_idx, variable] = np.nan
+    weights.loc[reduce_idx, variable] = 0
     return obs
 
 
-def reduce_training_data(y_obs, reduce_temp_trn, reduce_flow_trn):
+def reduce_training_data(y_obs, weights, reduce_temp_trn, reduce_flow_trn):
     """
     artificially reduce the amount of training data in the training dataset
     :param y_obs: [xarray dataset] the training observations data for flow and
     temp
+    :param weights:[xr dataset] weights that will be changed
     :param reduce_temp_trn: [float] fraction to reduce the temperature training
-    data by. For example, if 0.9, 90% of the temperature training data will be
-    changed to NaN
+    data by. For example, if 0.9, a random 90% of the weights for the
+    temperature training data will be set to zero
     :param reduce_flow_trn: [float] fraction to reduce the flow training data
-    by. For example, if 0.9, 90% of the flow training data will be changed to
-    NaN
-    :return: [xarray dataset] data with reduced amounts of training data
+    by. For example, if 0.9, a random 90% of the weights for the flow
+    training data will be set to zero
+    :return: [xarray dataset] updated weights (zero's where reduced)
     """
+    weights = weights.to_dataframe()
     df = y_obs.to_dataframe()
-    df_reduced = reduce_one_variable(df, 'seg_tave_water', reduce_temp_trn)
-    df_reduced = reduce_one_variable(df_reduced, 'seg_outflow', reduce_flow_trn)
-    return df_reduced.to_xarray()
+    wgt_reduced = reduce_one_variable(df, 'seg_tave_water', weights,
+                                      reduce_temp_trn)
+    wgt_reduced = reduce_one_variable(wgt_reduced, 'seg_outflow', wgt_reduced,
+                                      reduce_flow_trn)
+    return wgt_reduced.to_xarray()
 
 
 def convert_batch_reshape(dataset):
@@ -391,9 +402,10 @@ def get_y_obs(obs_files, pretrain_file, finetune_vars):
 
 
 def prep_data(obs_temper_file, obs_flow_file, pretrain_file, distfile, x_vars,
-              catch_prop_file=None, pretrain_vars='both', finetune_vars='both',
-              test_start_date='2004-09-30', n_test_yr=12, reduce_temp_trn=0,
-              reduce_flow_trn=0, exclude_file=None, log_q=False, out_file=None):
+              catch_prop_file=None, test_start_date='2004-09-30', n_test_yr=12,
+              reduce_temp_trn=0, reduce_flow_trn=0, reduce_temp_pretrn=0,
+              reduce_flow_pretrn=0, exclude_file=None, log_q=False,
+              out_file=None):
     """
     prepare input and output data for DL model training read in and process
     data into training and testing datasets. the training and testing data are
@@ -409,12 +421,18 @@ def prep_data(obs_temper_file, obs_flow_file, pretrain_file, distfile, x_vars,
     :param finetune_vars: [str] 'flow', 'temp', or 'both'
     :param test_start_date: [str] the date to start for the test period
     :param n_test_yr: [int] number of years to take for the test period
+    :param reduce_temp_pretrn: [float] fraction to reduce the temperature
+    pretraining data by. For example, if 0.9, 90% of the temperature training
+    data weights will be changed to zero for pretraining
+    :param reduce_temp_pretrn: [float] fraction to reduce the flow pretraining
+    data by. For example, if 0.9, 90% of the flow training data weights will be
+    changed to zero for pretraining
     :param reduce_temp_trn: [float] fraction to reduce the temperature training
-    data by. For example, if 0.9, 90% of the temperature training data will be
-    changed to NaN
+    finetuning data by. For example, if 0.9, 90% of the temperature training
+    data weights will be changed to zero for finetuning
     :param reduce_flow_trn: [float] fraction to reduce the flow training data
-    by. For example, if 0.9, 90% of the flow training data will be changed to
-    NaN
+    finetuning data by. For example, if 0.9, 90% of the flow training data
+    weights will be changed to zero for finetuning
     :param exclude_file: [str] path to exclude file
     :param log_q: [bool] whether or not to take the log of discharge in training
     :param out_file: [str] file to where the values will be written
@@ -448,8 +466,6 @@ def prep_data(obs_temper_file, obs_flow_file, pretrain_file, distfile, x_vars,
     # read, filter observations for finetuning
     y_obs = read_multiple_obs([obs_temper_file, obs_flow_file], pretrain_file)
     y_obs_trn, y_obs_tst = separate_trn_tst(y_obs, test_start_date, n_test_yr)
-    y_obs_trn = reduce_training_data(y_obs_trn, reduce_temp_trn,
-                                     reduce_flow_trn)
     y_vars = ['seg_tave_water', 'seg_outflow']
     y_pre = ds_pre[y_vars]
     y_pre_trn, _ = separate_trn_tst(y_pre, test_start_date, n_test_yr)
@@ -463,9 +479,10 @@ def prep_data(obs_temper_file, obs_flow_file, pretrain_file, distfile, x_vars,
         exclude_segs = read_exclude_segs_file(exclude_file)
     else:
         exclude_segs = None
-    y_pre_wgts = create_weight_vectors(y_pre_trn, pretrain_vars,
-                                       exclude_segs=None)
-    y_obs_wgts = create_weight_vectors(y_pre_trn, finetune_vars,
+    y_pre_wgts = create_weight_vectors(y_pre_trn, reduce_temp_pretrn,
+                                       reduce_flow_pretrn, exclude_segs=None)
+    y_obs_wgts = create_weight_vectors(y_pre_trn, reduce_temp_trn,
+                                       reduce_flow_trn,
                                        exclude_segs=exclude_segs)
 
     # scale y training data and get the mean and std

--- a/river_dl/preproc_utils.py
+++ b/river_dl/preproc_utils.py
@@ -241,25 +241,6 @@ def initialize_weights(y_data, initial_val=1):
     return weights
 
 
-def change_weights_by_outcols(weights, out_cols):
-    """
-    modify the weights by the outcolumns
-    :param weights:[xr dataset] weights
-    :param out_cols:[str] which columns you will be looking at. should be
-    'temp', 'flow', or 'both'
-    :returns: [xr dataset] modified weights
-    """
-    if out_cols == "both":
-        pass
-    elif out_cols == 'temp':
-        weights.seg_outflow.loc[:, :] = 0
-    elif out_cols == 'flow':
-        weights.seg_tave_water.loc[:, :] = 0
-    else:
-        raise ValueError('out_cols needs to be "flow", "temp", or "both"')
-    return weights
-
-
 def create_weight_vectors(y_data, reduce_temp_trn, reduce_flow_trn,
                           exclude_segs):
     """


### PR DESCRIPTION
This is a pretty big change in how the variables are being reduced in the sense that we are no longer using the `pretrain_vars` and `finetune_vars` arguments. I am now using a more flexible approach. If we wanted to reproduce what we had before than:
|old| new|
|---|---|
|`pretrain_vars = 'both'`| `reduce_temp_pretrn = 0`, `reduce_flow_pretrn = 0`|
|`pretrain_vars = 'flow'`| `reduce_temp_pretrn = 1`, `reduce_flow_pretrn = 0`|
|`finetune_vars= 'both'`| `reduce_temp_trn = 0`, `reduce_flow_trn = 0`|
|`finetune_vars= 'flow'`| `reduce_temp_trn = 1`, `reduce_flow_trn = 0`|

So this update will make the code non-backwards-compatible. I could leave those variables in there, but I just don't want to keep dragging them along.